### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Verify
+        run: ./mvnw -B verify
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Check formatting
+        run: npm run format:check
+      - name: Build
+        run: npm run build

--- a/client/src/context/SessionContext.jsx
+++ b/client/src/context/SessionContext.jsx
@@ -43,6 +43,7 @@ export function SessionProvider({ children }) {
   return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useSession() {
   return useContext(SessionContext);
 }

--- a/server/src/test/java/com/adityamehrotra/tradesim/TradeSimApplicationTests.java
+++ b/server/src/test/java/com/adityamehrotra/tradesim/TradeSimApplicationTests.java
@@ -1,8 +1,0 @@
-package com.adityamehrotra.tradesim;
-
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
-
-@SpringBootTest
-@TestPropertySource(locations = "classpath:application.properties")
-class TradeSimApplicationTests {}

--- a/server/src/test/java/com/adityamehrotra/tradesim/engine/OrderBookTest.java
+++ b/server/src/test/java/com/adityamehrotra/tradesim/engine/OrderBookTest.java
@@ -1,0 +1,132 @@
+package com.adityamehrotra.tradesim.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OrderBookTest {
+  private long sequence = 0;
+
+  private Order limit(long owner, Side side, long priceCents, long quantity) {
+    return new Order(++sequence, owner, side, OrderType.LIMIT, priceCents, quantity);
+  }
+
+  private Order market(long owner, Side side, long quantity) {
+    return new Order(++sequence, owner, side, OrderType.MARKET, 0, quantity);
+  }
+
+  @Test
+  void aggressorTradesAtThePassivePrice() {
+    OrderBook book = new OrderBook("NOVA");
+    Order resting = limit(1, Side.SELL, 1000, 50);
+    book.submit(resting);
+
+    List<Trade> trades = book.submit(limit(2, Side.BUY, 1050, 30));
+
+    assertEquals(1, trades.size());
+    assertEquals(1000, trades.get(0).getPriceCents());
+    assertEquals(30, trades.get(0).getQuantity());
+  }
+
+  @Test
+  void betterPriceThenEarlierOrderFillsFirst() {
+    OrderBook book = new OrderBook("NOVA");
+    book.submit(limit(1, Side.SELL, 1100, 10));
+    Order earlyBest = limit(1, Side.SELL, 1000, 10);
+    Order lateBest = limit(1, Side.SELL, 1000, 10);
+    book.submit(earlyBest);
+    book.submit(lateBest);
+
+    List<Trade> trades = book.submit(market(2, Side.BUY, 15));
+
+    assertEquals(1000, trades.get(0).getPriceCents());
+    assertEquals(earlyBest.getId(), trades.get(0).getSellOrderId());
+    assertEquals(lateBest.getId(), trades.get(1).getSellOrderId());
+  }
+
+  @Test
+  void unfilledLimitRemainderRests() {
+    OrderBook book = new OrderBook("NOVA");
+    book.submit(limit(1, Side.SELL, 1000, 10));
+
+    Order aggressive = limit(2, Side.BUY, 1000, 25);
+    book.submit(aggressive);
+
+    assertEquals(10, aggressive.getFilledQuantity());
+    assertEquals(15, aggressive.getRemainingQuantity());
+    assertEquals(1000, book.bestBidCents());
+  }
+
+  @Test
+  void marketOrderDropsWhatItCannotFill() {
+    OrderBook book = new OrderBook("NOVA");
+    book.submit(limit(1, Side.SELL, 1000, 10));
+
+    Order sweep = market(2, Side.BUY, 40);
+    book.submit(sweep);
+
+    assertEquals(10, sweep.getFilledQuantity());
+    assertEquals(30, sweep.getRemainingQuantity());
+    assertNull(book.bestAskCents());
+    assertNull(book.bestBidCents());
+  }
+
+  @Test
+  void cancelRemovesARestingOrder() {
+    OrderBook book = new OrderBook("NOVA");
+    Order resting = limit(1, Side.BUY, 900, 40);
+    book.submit(resting);
+
+    assertTrue(book.cancel(resting.getId()));
+    assertNull(book.bestBidCents());
+    assertEquals(0, book.submit(limit(2, Side.SELL, 900, 10)).size());
+  }
+
+  @Test
+  void aPartiallyFilledOrderCanStillBeCancelled() {
+    OrderBook book = new OrderBook("NOVA");
+    Order resting = limit(1, Side.BUY, 900, 40);
+    book.submit(resting);
+    book.submit(limit(2, Side.SELL, 900, 15));
+
+    assertEquals(25, resting.getRemainingQuantity());
+    assertTrue(book.cancel(resting.getId()));
+    assertNull(book.bestBidCents());
+  }
+
+  @Test
+  void matchingNeverLeavesACrossedBook() {
+    OrderBook book = new OrderBook("NOVA");
+    book.submit(limit(1, Side.BUY, 900, 40));
+    book.submit(limit(2, Side.SELL, 1100, 40));
+    book.submit(limit(3, Side.SELL, 900, 25));
+
+    Long bestBid = book.bestBidCents();
+    Long bestAsk = book.bestAskCents();
+    assertTrue(bestBid == null || bestAsk == null || bestBid < bestAsk);
+  }
+
+  @Test
+  void sharesAreConservedAcrossAMatch() {
+    OrderBook book = new OrderBook("NOVA");
+    book.submit(limit(1, Side.SELL, 1000, 30));
+    book.submit(limit(1, Side.SELL, 1010, 30));
+
+    List<Trade> trades = book.submit(market(2, Side.BUY, 45));
+
+    long traded = trades.stream().mapToLong(Trade::getQuantity).sum();
+    assertEquals(45, traded);
+  }
+
+  @Test
+  void orderRejectsNonPositiveQuantityAndPrice() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new Order(1, 1, Side.BUY, OrderType.LIMIT, 1000, 0));
+    assertThrows(
+        IllegalArgumentException.class, () -> new Order(1, 1, Side.BUY, OrderType.LIMIT, 0, 10));
+  }
+}

--- a/server/src/test/java/com/adityamehrotra/tradesim/service/PositionServiceTest.java
+++ b/server/src/test/java/com/adityamehrotra/tradesim/service/PositionServiceTest.java
@@ -1,0 +1,102 @@
+package com.adityamehrotra.tradesim.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.adityamehrotra.tradesim.model.Lot;
+import com.adityamehrotra.tradesim.model.Portfolio;
+import com.adityamehrotra.tradesim.model.Position;
+import com.adityamehrotra.tradesim.repository.PortfolioRepository;
+import com.adityamehrotra.tradesim.repository.PositionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PositionServiceTest {
+  @Mock private PortfolioRepository portfolioRepository;
+  @Mock private PositionRepository positionRepository;
+  @InjectMocks private PositionService service;
+
+  private Portfolio portfolio(double cash, double reserved) {
+    Portfolio portfolio = new Portfolio();
+    portfolio.setCash(cash);
+    portfolio.setReservedCash(reserved);
+    return portfolio;
+  }
+
+  @Test
+  void reservesCashWhenBuyingPowerCovers() {
+    Portfolio portfolio = portfolio(1000.0, 0.0);
+    when(portfolioRepository.findByPortfolioID(1)).thenReturn(portfolio);
+
+    assertTrue(service.reserveCash(1, 50000));
+    assertEquals(500.0, portfolio.getReservedCash());
+  }
+
+  @Test
+  void refusesToReserveMoreCashThanAvailable() {
+    Portfolio portfolio = portfolio(100.0, 0.0);
+    when(portfolioRepository.findByPortfolioID(1)).thenReturn(portfolio);
+
+    assertFalse(service.reserveCash(1, 50000));
+    verify(portfolioRepository, never()).save(any());
+  }
+
+  @Test
+  void buyFillSpendsCashReleasesReserveAndAddsLot() {
+    Portfolio portfolio = portfolio(1000.0, 500.0);
+    when(portfolioRepository.findByPortfolioID(1)).thenReturn(portfolio);
+    when(positionRepository.findByPortfolioIDAndSymbol(1, "NOVA")).thenReturn(null);
+
+    service.applyBuyFill(1, "NOVA", 10, 5000, 5000);
+
+    assertEquals(500.0, portfolio.getCash());
+    assertEquals(0.0, portfolio.getReservedCash());
+
+    ArgumentCaptor<Position> saved = ArgumentCaptor.forClass(Position.class);
+    verify(positionRepository).save(saved.capture());
+    assertEquals(10, saved.getValue().getQuantity());
+    assertEquals(1, saved.getValue().getLots().size());
+  }
+
+  @Test
+  void sellFillConsumesLotsFifoAndRealizesProfit() {
+    Position position = new Position(1, "NOVA");
+    position.setQuantity(20);
+    position.setReservedQuantity(15);
+    position.getLots().add(new Lot(10, 1000));
+    position.getLots().add(new Lot(10, 2000));
+    Portfolio portfolio = portfolio(0.0, 0.0);
+    when(portfolioRepository.findByPortfolioID(1)).thenReturn(portfolio);
+    when(positionRepository.findByPortfolioIDAndSymbol(1, "NOVA")).thenReturn(position);
+
+    service.applySellFill(1, "NOVA", 15, 2500);
+
+    assertEquals(375.0, portfolio.getCash());
+    assertEquals(5, position.getQuantity());
+    assertEquals(0, position.getReservedQuantity());
+    assertEquals(175.0, position.getRealizedPnl(), 1e-9);
+    assertEquals(1, position.getLots().size());
+    assertEquals(5, position.getLots().get(0).getQuantity());
+  }
+
+  @Test
+  void refusesToReserveMoreSharesThanAreFree() {
+    Position position = new Position(1, "NOVA");
+    position.setQuantity(10);
+    position.setReservedQuantity(8);
+    when(positionRepository.findByPortfolioIDAndSymbol(1, "NOVA")).thenReturn(position);
+
+    assertFalse(service.reserveShares(1, "NOVA", 5));
+    verify(positionRepository, never()).save(any());
+  }
+}


### PR DESCRIPTION
Adds a JUnit suite for the two parts worth trusting: the matching engine invariants (price-time priority, partial fills, cancels, no crossed book, share conservation) and portfolio accounting (cash and share reservation, buy fills, FIFO realized profit). Adds a GitHub Actions workflow that runs the backend verify and the frontend lint, format check, and build on push and pull request.

Removes the empty placeholder test that needed a database and asserted nothing.